### PR TITLE
supporting non-ha config for worker nodes

### DIFF
--- a/src/components/CostWizard/AddWorkerNodes.tsx
+++ b/src/components/CostWizard/AddWorkerNodes.tsx
@@ -22,7 +22,7 @@ export default function AddWorkerNodes() {
       timeConsumption: timeConsumption,
       machineType: config.nodeConfig.MachineTypes[0],
       VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
-      minAutoscaler: config.nodeConfig.AutoScalerMin.Default,
+      minAutoscaler: config.nodeConfig.AutoScalerMin.DefaultWorkerPools,
     };
     setMachineSetup((prevState) => prevState.concat(newMachine));
   };

--- a/src/components/CostWizard/AddWorkerNodes.tsx
+++ b/src/components/CostWizard/AddWorkerNodes.tsx
@@ -22,7 +22,7 @@ export default function AddWorkerNodes() {
       timeConsumption: timeConsumption,
       machineType: config.nodeConfig.MachineTypes[0],
       VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
-      minAutoscaler: config.nodeConfig.AutoScalerMin.DefaultWorkerPools,
+      minAutoscaler: config.nodeConfig.AutoScalerMin.DefaultWorkerNodes,
     };
     setMachineSetup((prevState) => prevState.concat(newMachine));
   };

--- a/src/components/CostWizard/MachineSetupForm.tsx
+++ b/src/components/CostWizard/MachineSetupForm.tsx
@@ -64,6 +64,7 @@ export default function MachineSetupForm({
       <MinAutoscalerInputField
         autoScalerMin={autoScalerMin}
         setAutoScalerMin={setAutoScalerMin}
+        workerNode={workerNode}
       />
     </Form>
   );

--- a/src/components/CostWizard/UserInputs/nodes/MinAutoscalerInputField.tsx
+++ b/src/components/CostWizard/UserInputs/nodes/MinAutoscalerInputField.tsx
@@ -6,13 +6,15 @@ import HeaderWithInfo from '../../common/HeaderWithInfo';
 interface Props {
   autoScalerMin: number;
   setAutoScalerMin: React.Dispatch<React.SetStateAction<number>>;
+  workerNode: boolean;
 }
 export default function MinAutoscalerInputField({
   autoScalerMin,
   setAutoScalerMin,
+  workerNode
 }: Props) {
   const configuration = config.nodeConfig.AutoScalerMin;
-  const min = configuration.Min;
+  const min = workerNode ? configuration.MinWorkerNodes : configuration.Min;
   const max = configuration.Max;
   const step = configuration.Step;
 

--- a/src/config.json
+++ b/src/config.json
@@ -4,6 +4,7 @@
   "nodeConfig": {
     "AutoScalerMin": {
       "Default": 3,
+      "DefaultWorkerPools": 1,
       "Min": 3,
       "Max": 300,
       "Step": 1

--- a/src/config.json
+++ b/src/config.json
@@ -4,8 +4,9 @@
   "nodeConfig": {
     "AutoScalerMin": {
       "Default": 3,
-      "DefaultWorkerPools": 1,
+      "DefaultWorkerNodes": 1,
       "Min": 3,
+      "MinWorkerNodes": 1,
       "Max": 300,
       "Step": 1
     },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- possibility to compute cost calculation on worker nodes with an non-HA setup (1 or 2 nodes minimum instead of 3)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
