### PR TITLE
fix: Single-source timeConsumption from the global atom

### DIFF
--- a/src/components/CostWizard/AddWorkerNodes.tsx
+++ b/src/components/CostWizard/AddWorkerNodes.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { Button, FlexBox, Icon, Title } from '@ui5/webcomponents-react';
 import './AddWorkerNodes.css';
 import {
@@ -8,15 +8,12 @@ import {
 import MachineSetupForm from './MachineSetupForm';
 import openLinks from './Functions/openLinks';
 import config from '../../config.json';
-import { timeConsumptionState } from '../../state/additionalConfig/timeConsumptionState';
 
 export default function AddWorkerNodes() {
   const [machineSetup, setMachineSetup] = useAtom(additionalMachineSetupState);
-  const timeConsumption = useAtomValue(timeConsumptionState);
 
   const addMachineSetup = () => {
     const newMachine: MachineSetup = {
-      timeConsumption: timeConsumption,
       machineType: config.nodeConfig.MachineTypes[0],
       VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
       minAutoscaler: config.nodeConfig.AutoScalerMin.DefaultWorkerNodes,

--- a/src/components/CostWizard/Buttons/CSVDownloadButton.tsx
+++ b/src/components/CostWizard/Buttons/CSVDownloadButton.tsx
@@ -12,6 +12,7 @@ import { premiumGBQuantityState } from '../../../state/storage/premiumGBQuantity
 import { snapshotGBQuantityState } from '../../../state/storage/snapshotGBQuantityState';
 import { redisState } from '../../../state/additionalConfig/redisState';
 import { applyConversionRateState } from '../../../state/additionalConfig/applyConversionRateState';
+import { timeConsumptionState } from '../../../state/additionalConfig/timeConsumptionState';
 import {
   nodeConfigCostsAtom,
   storageCostsAtom,
@@ -27,6 +28,7 @@ export default function CSVDownloadButton() {
   const snapshotStorageQuantity = useAtomValue(snapshotGBQuantityState);
   const redisSize = useAtomValue(redisState);
   const conversionRate = useAtomValue(applyConversionRateState);
+  const timeConsumption = useAtomValue(timeConsumptionState);
   const nodeConfigCosts = useAtomValue(nodeConfigCostsAtom);
   const storageCosts = useAtomValue(storageCostsAtom);
   const additionalCosts = useAtomValue(additionalCostsAtom);
@@ -47,6 +49,7 @@ export default function CSVDownloadButton() {
           additionalCosts,
           conversionRate,
           totalCosts,
+          timeConsumption,
           redisSize,
           exportFormat: ExportFormat.CSV,
         })

--- a/src/components/CostWizard/Buttons/XlsxDownloadButton.tsx
+++ b/src/components/CostWizard/Buttons/XlsxDownloadButton.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../state/nodes/machineSetupState';
 import { redisState } from '../../../state/additionalConfig/redisState';
 import { applyConversionRateState } from '../../../state/additionalConfig/applyConversionRateState';
+import { timeConsumptionState } from '../../../state/additionalConfig/timeConsumptionState';
 import {
   nodeConfigCostsAtom,
   storageCostsAtom,
@@ -27,6 +28,7 @@ export default function XlsxDownloadButton() {
   const additionalMachineSetup = useAtomValue(additionalMachineSetupState);
   const redisSize = useAtomValue(redisState);
   const conversionRate = useAtomValue(applyConversionRateState);
+  const timeConsumption = useAtomValue(timeConsumptionState);
   const nodeConfigCosts = useAtomValue(nodeConfigCostsAtom);
   const storageCosts = useAtomValue(storageCostsAtom);
   const additionalCosts = useAtomValue(additionalCostsAtom);
@@ -46,6 +48,7 @@ export default function XlsxDownloadButton() {
           additionalCosts,
           conversionRate,
           totalCosts,
+          timeConsumption,
           redisSize,
           exportFormat: ExportFormat.XLSX,
         })

--- a/src/components/CostWizard/Functions/exportToFile.ts
+++ b/src/components/CostWizard/Functions/exportToFile.ts
@@ -17,6 +17,7 @@ interface Props {
   additionalCosts: number;
   conversionRate: number;
   totalCosts: TotalCosts;
+  timeConsumption: number;
   exportFormat: ExportFormat;
 }
 
@@ -37,6 +38,7 @@ export default function exportToFile(props: Props) {
     additionalCosts,
     conversionRate,
     totalCosts,
+    timeConsumption,
     exportFormat,
   } = props;
 
@@ -51,7 +53,7 @@ export default function exportToFile(props: Props) {
       index === 0 ? 'Base Worker Node Pool' : `Worker Node Pool ${index}`;
 
     const poolCost = calculateNodeConfigCosts({
-      timeConsumption: machine.timeConsumption,
+      timeConsumption,
       computeUnits: machine.VMSize.computeUnits,
       minAutoscaler: machine.minAutoscaler,
       machineTypeFactor: machine.machineType.multiple,
@@ -62,11 +64,13 @@ export default function exportToFile(props: Props) {
       ['Machine Type', machine.machineType.value],
       ['VM Size', machine.VMSize.value],
       ['Autoscaler Min', machine.minAutoscaler],
-      ['Time Consumption', `${machine.timeConsumption} hrs`],
       ['Pool Cost', `${roundDecimals(poolCost, true)} CU`],
       [''],
     );
   });
+
+  // Time Consumption applies globally to all node pools and storage
+  dataArray.push(['Time Consumption', `${timeConsumption} hrs`], ['']);
 
   // Storage
   dataArray.push(

--- a/src/components/CostWizard/MachineSetupForm.tsx
+++ b/src/components/CostWizard/MachineSetupForm.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { useAtomValue } from 'jotai';
 import { Form } from '@ui5/webcomponents-react';
 import VMsizeSelect from './UserInputs/nodes/VMsizeSelect';
 import MachineTypeSelect from './UserInputs/nodes/MachineTypeSelect';
@@ -10,7 +9,6 @@ import {
   MachineType,
   VMSize,
 } from '../../state/nodes/machineSetupState';
-import { timeConsumptionState } from '../../state/additionalConfig/timeConsumptionState';
 
 interface Props {
   machine: MachineSetup;
@@ -23,28 +21,26 @@ export default function MachineSetupForm({
   updateMachine,
   workerNode,
 }: Props) {
-  const timeConsumption = useAtomValue(timeConsumptionState);
-
   const setMachineType = useCallback(
     (machineType: MachineType) => {
       const VMSize = machineType.VMSizeOptions[0];
-      updateMachine({ ...machine, machineType, VMSize, timeConsumption });
+      updateMachine({ ...machine, machineType, VMSize });
     },
-    [machine, updateMachine, timeConsumption],
+    [machine, updateMachine],
   );
 
   const setVMSize = useCallback(
     (VMSize: VMSize) => {
-      updateMachine({ ...machine, VMSize, timeConsumption });
+      updateMachine({ ...machine, VMSize });
     },
-    [machine, updateMachine, timeConsumption],
+    [machine, updateMachine],
   );
 
   const setAutoScalerMin = useCallback(
     (minAutoscaler: number) => {
-      updateMachine({ ...machine, minAutoscaler, timeConsumption });
+      updateMachine({ ...machine, minAutoscaler });
     },
-    [machine, updateMachine, timeConsumption],
+    [machine, updateMachine],
   );
 
   return (

--- a/src/state/nodes/machineSetupState.ts
+++ b/src/state/nodes/machineSetupState.ts
@@ -15,12 +15,10 @@ export interface VMSize {
 export interface MachineSetup {
   machineType: MachineType;
   minAutoscaler: number;
-  timeConsumption: number;
   VMSize: VMSize;
 }
 
 export const baseMachineSetupState = atom<MachineSetup>({
-  timeConsumption: config.AdditionalConfig.TimeConsumption,
   machineType: config.nodeConfig.MachineTypes[0],
   VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
   minAutoscaler: config.nodeConfig.AutoScalerMin.Default,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "types": ["vite/client"],
     "skipLibCheck": false,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- had to fix a couple of leftover incosistencies, since timeConsumption is now a global atom
- ...
- ...

**Related issue(s)**
#---
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
