### PR TITLE
feat: Display default node volume size in VM size dropdown

### DIFF
--- a/src/calculatorFunctions/defaultVolumeSize/calculateDefaultVolumeSize.test.ts
+++ b/src/calculatorFunctions/defaultVolumeSize/calculateDefaultVolumeSize.test.ts
@@ -1,0 +1,64 @@
+import calculateDefaultVolumeSize from './calculateDefaultVolumeSize';
+import { expect, test, describe } from 'vitest';
+
+// Config values (from config.json → nodeConfig.volumeFormula)
+//   volumeBase   = 30
+//   volumeFactor = 8
+//   volumeMin    = 80
+//   volumeMax    = 250
+//
+// Formula:
+//   normalized = max(vcpus / 2, memoryGib / 8)
+//   raw        = floor(volumeBase + normalized * volumeFactor)
+//   size       = min(volumeMax, max(volumeMin, raw))
+
+describe('calculateDefaultVolumeSize — General Purpose (1:4 CPU:RAM)', () => {
+  test('2 CPU / 8 GB clamps up to volumeMin', () => {
+    // normalized = max(1, 1) = 1; raw = 38 → 80
+    expect(calculateDefaultVolumeSize(2, 8)).toBe(80);
+  });
+
+  test('16 CPU / 64 GB sits inside the range', () => {
+    // normalized = max(8, 8) = 8; raw = 94
+    expect(calculateDefaultVolumeSize(16, 64)).toBe(94);
+  });
+
+  test('48 CPU / 192 GB sits near the top of the range', () => {
+    // normalized = max(24, 24) = 24; raw = 222
+    expect(calculateDefaultVolumeSize(48, 192)).toBe(222);
+  });
+
+  test('64 CPU / 256 GB clamps down to volumeMax', () => {
+    // normalized = max(32, 32) = 32; raw = 286 → 250
+    expect(calculateDefaultVolumeSize(64, 256)).toBe(250);
+  });
+});
+
+describe('calculateDefaultVolumeSize — Compute Optimized (CPU dominates)', () => {
+  test('2 CPU / 4 GB clamps up to volumeMin (vcpus wins)', () => {
+    // normalized = max(1, 0.5) = 1; raw = 38 → 80
+    expect(calculateDefaultVolumeSize(2, 4)).toBe(80);
+  });
+
+  test('32 CPU / 64 GB sits inside the range', () => {
+    // normalized = max(16, 8) = 16; raw = 158
+    expect(calculateDefaultVolumeSize(32, 64)).toBe(158);
+  });
+});
+
+describe('calculateDefaultVolumeSize — Memory Intensive (RAM dominates)', () => {
+  test('2 CPU / 16 GB clamps up to volumeMin (memoryGib wins)', () => {
+    // normalized = max(1, 2) = 2; raw = 46 → 80
+    expect(calculateDefaultVolumeSize(2, 16)).toBe(80);
+  });
+
+  test('8 CPU / 64 GB sits inside the range', () => {
+    // normalized = max(4, 8) = 8; raw = 94
+    expect(calculateDefaultVolumeSize(8, 64)).toBe(94);
+  });
+
+  test('64 CPU / 512 GB clamps down to volumeMax', () => {
+    // normalized = max(32, 64) = 64; raw = 542 → 250
+    expect(calculateDefaultVolumeSize(64, 512)).toBe(250);
+  });
+});

--- a/src/calculatorFunctions/defaultVolumeSize/calculateDefaultVolumeSize.ts
+++ b/src/calculatorFunctions/defaultVolumeSize/calculateDefaultVolumeSize.ts
@@ -1,0 +1,16 @@
+import config from '../../config.json';
+
+// Mirrors the KCR consumption-reporter formula
+// (helm/kcr/templates/nodemeterconfig.yaml). Keep parameters in
+// config.nodeConfig.volumeFormula in sync with that source.
+export default function calculateDefaultVolumeSize(
+  vcpus: number,
+  memoryGib: number,
+): number {
+  const { volumeBase, volumeFactor, volumeMin, volumeMax } =
+    config.nodeConfig.volumeFormula;
+
+  const normalizedResource = Math.max(vcpus / 2, memoryGib / 8);
+  const raw = Math.floor(volumeBase + normalizedResource * volumeFactor);
+  return Math.min(volumeMax, Math.max(volumeMin, raw));
+}

--- a/src/components/CostWizard/UserInputs/nodes/VMsizeSelect.tsx
+++ b/src/components/CostWizard/UserInputs/nodes/VMsizeSelect.tsx
@@ -1,5 +1,6 @@
 import { Option, Select, Title } from '@ui5/webcomponents-react';
 import { VMSize } from '../../../../state/nodes/machineSetupState';
+import calculateDefaultVolumeSize from '../../../../calculatorFunctions/defaultVolumeSize/calculateDefaultVolumeSize';
 
 interface Props {
   VMSize: VMSize;
@@ -19,7 +20,8 @@ export default function VMsizeSelect({
     setVMSize({
       value: selection.value ?? '',
       computeUnits: Number(selection.compute_units),
-      defaultVolumeSize: Number(selection.default_volume_size),
+      vcpus: Number(selection.vcpus),
+      memoryGib: Number(selection.memory_gib),
     });
   };
 
@@ -40,9 +42,10 @@ export default function VMsizeSelect({
             value={item.value}
             data-value={item.value}
             data-compute_units={item.computeUnits}
-            data-default_volume_size={item.defaultVolumeSize}
+            data-vcpus={item.vcpus}
+            data-memory_gib={item.memoryGib}
           >
-            {`${item.value} - ${item.defaultVolumeSize} GB volume`}
+            {`${item.value} - ${calculateDefaultVolumeSize(item.vcpus, item.memoryGib)} GB volume`}
           </Option>
         ))}
       </Select>

--- a/src/components/CostWizard/UserInputs/nodes/VMsizeSelect.tsx
+++ b/src/components/CostWizard/UserInputs/nodes/VMsizeSelect.tsx
@@ -19,6 +19,7 @@ export default function VMsizeSelect({
     setVMSize({
       value: selection.value ?? '',
       computeUnits: Number(selection.compute_units),
+      defaultVolumeSize: Number(selection.default_volume_size),
     });
   };
 
@@ -27,14 +28,21 @@ export default function VMsizeSelect({
       <Title className="wizard-subheader" level="H5" size="H5">
         Virtual Machine Size
       </Title>
-      <Select id="vm-size-select" value={VMSize.value} onChange={onChange}>
+      <Select
+        id="vm-size-select"
+        value={VMSize.value}
+        onChange={onChange}
+        style={{ width: '20rem' }}
+      >
         {VMSizeOptions.map((item) => (
           <Option
             key={item.value}
+            value={item.value}
             data-value={item.value}
             data-compute_units={item.computeUnits}
+            data-default_volume_size={item.defaultVolumeSize}
           >
-            {item.value}
+            {`${item.value} - ${item.defaultVolumeSize} GB volume`}
           </Option>
         ))}
       </Select>

--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,12 @@
       "Max": 300,
       "Step": 1
     },
+    "volumeFormula": {
+      "volumeBase": 30,
+      "volumeFactor": 8,
+      "volumeMin": 80,
+      "volumeMax": 250
+    },
     "MachineTypes": [
       {
         "value": "General Purpose",
@@ -18,37 +24,44 @@
           {
             "value": "2 CPU - 8GB RAM",
             "computeUnits": 3,
-            "defaultVolumeSize": 0
+            "vcpus": 2,
+            "memoryGib": 8
           },
           {
             "value": "4 CPU - 16GB RAM",
             "computeUnits": 4,
-            "defaultVolumeSize": 0
+            "vcpus": 4,
+            "memoryGib": 16
           },
           {
             "value": "8 CPU - 32GB RAM",
             "computeUnits": 8,
-            "defaultVolumeSize": 0
+            "vcpus": 8,
+            "memoryGib": 32
           },
           {
             "value": "16 CPU - 64GB RAM",
             "computeUnits": 16,
-            "defaultVolumeSize": 0
+            "vcpus": 16,
+            "memoryGib": 64
           },
           {
             "value": "32 CPU - 128GB RAM",
             "computeUnits": 32,
-            "defaultVolumeSize": 0
+            "vcpus": 32,
+            "memoryGib": 128
           },
           {
             "value": "48 CPU - 192GB RAM",
             "computeUnits": 48,
-            "defaultVolumeSize": 0
+            "vcpus": 48,
+            "memoryGib": 192
           },
           {
             "value": "64 CPU - 256GB RAM",
             "computeUnits": 64,
-            "defaultVolumeSize": 0
+            "vcpus": 64,
+            "memoryGib": 256
           }
         ]
       },
@@ -59,37 +72,44 @@
           {
             "value": "2 CPU - 4GB RAM",
             "computeUnits": 3,
-            "defaultVolumeSize": 0
+            "vcpus": 2,
+            "memoryGib": 4
           },
           {
             "value": "4 CPU - 8GB RAM",
             "computeUnits": 4,
-            "defaultVolumeSize": 0
+            "vcpus": 4,
+            "memoryGib": 8
           },
           {
             "value": "8 CPU - 16GB RAM",
             "computeUnits": 8,
-            "defaultVolumeSize": 0
+            "vcpus": 8,
+            "memoryGib": 16
           },
           {
             "value": "16 CPU - 32GB RAM",
             "computeUnits": 16,
-            "defaultVolumeSize": 0
+            "vcpus": 16,
+            "memoryGib": 32
           },
           {
             "value": "32 CPU - 64GB RAM",
             "computeUnits": 32,
-            "defaultVolumeSize": 0
+            "vcpus": 32,
+            "memoryGib": 64
           },
           {
             "value": "48 CPU - 96GB RAM",
             "computeUnits": 48,
-            "defaultVolumeSize": 0
+            "vcpus": 48,
+            "memoryGib": 96
           },
           {
             "value": "64 CPU - 128GB RAM",
             "computeUnits": 64,
-            "defaultVolumeSize": 0
+            "vcpus": 64,
+            "memoryGib": 128
           }
         ]
       },
@@ -100,37 +120,44 @@
           {
             "value": "2 CPU - 16GB RAM",
             "computeUnits": 3,
-            "defaultVolumeSize": 0
+            "vcpus": 2,
+            "memoryGib": 16
           },
           {
             "value": "4 CPU - 32GB RAM",
             "computeUnits": 4,
-            "defaultVolumeSize": 0
+            "vcpus": 4,
+            "memoryGib": 32
           },
           {
             "value": "8 CPU - 64GB RAM",
             "computeUnits": 8,
-            "defaultVolumeSize": 0
+            "vcpus": 8,
+            "memoryGib": 64
           },
           {
             "value": "16 CPU - 128GB RAM",
             "computeUnits": 16,
-            "defaultVolumeSize": 0
+            "vcpus": 16,
+            "memoryGib": 128
           },
           {
             "value": "32 CPU - 256GB RAM",
             "computeUnits": 32,
-            "defaultVolumeSize": 0
+            "vcpus": 32,
+            "memoryGib": 256
           },
           {
             "value": "48 CPU - 384GB RAM",
             "computeUnits": 48,
-            "defaultVolumeSize": 0
+            "vcpus": 48,
+            "memoryGib": 384
           },
           {
             "value": "64 CPU - 512GB RAM",
             "computeUnits": 64,
-            "defaultVolumeSize": 0
+            "vcpus": 64,
+            "memoryGib": 512
           }
         ]
       }

--- a/src/config.json
+++ b/src/config.json
@@ -17,31 +17,38 @@
         "VMSizeOptions": [
           {
             "value": "2 CPU - 8GB RAM",
-            "computeUnits": 3
+            "computeUnits": 3,
+            "defaultVolumeSize": 0
           },
           {
             "value": "4 CPU - 16GB RAM",
-            "computeUnits": 4
+            "computeUnits": 4,
+            "defaultVolumeSize": 0
           },
           {
             "value": "8 CPU - 32GB RAM",
-            "computeUnits": 8
+            "computeUnits": 8,
+            "defaultVolumeSize": 0
           },
           {
             "value": "16 CPU - 64GB RAM",
-            "computeUnits": 16
+            "computeUnits": 16,
+            "defaultVolumeSize": 0
           },
           {
             "value": "32 CPU - 128GB RAM",
-            "computeUnits": 32
+            "computeUnits": 32,
+            "defaultVolumeSize": 0
           },
           {
             "value": "48 CPU - 192GB RAM",
-            "computeUnits": 48
+            "computeUnits": 48,
+            "defaultVolumeSize": 0
           },
           {
             "value": "64 CPU - 256GB RAM",
-            "computeUnits": 64
+            "computeUnits": 64,
+            "defaultVolumeSize": 0
           }
         ]
       },
@@ -51,31 +58,38 @@
         "VMSizeOptions": [
           {
             "value": "2 CPU - 4GB RAM",
-            "computeUnits": 3
+            "computeUnits": 3,
+            "defaultVolumeSize": 0
           },
           {
             "value": "4 CPU - 8GB RAM",
-            "computeUnits": 4
+            "computeUnits": 4,
+            "defaultVolumeSize": 0
           },
           {
             "value": "8 CPU - 16GB RAM",
-            "computeUnits": 8
+            "computeUnits": 8,
+            "defaultVolumeSize": 0
           },
           {
             "value": "16 CPU - 32GB RAM",
-            "computeUnits": 16
+            "computeUnits": 16,
+            "defaultVolumeSize": 0
           },
           {
             "value": "32 CPU - 64GB RAM",
-            "computeUnits": 32
+            "computeUnits": 32,
+            "defaultVolumeSize": 0
           },
           {
             "value": "48 CPU - 96GB RAM",
-            "computeUnits": 48
+            "computeUnits": 48,
+            "defaultVolumeSize": 0
           },
           {
             "value": "64 CPU - 128GB RAM",
-            "computeUnits": 64
+            "computeUnits": 64,
+            "defaultVolumeSize": 0
           }
         ]
       },
@@ -85,31 +99,38 @@
         "VMSizeOptions": [
           {
             "value": "2 CPU - 16GB RAM",
-            "computeUnits": 3
+            "computeUnits": 3,
+            "defaultVolumeSize": 0
           },
           {
             "value": "4 CPU - 32GB RAM",
-            "computeUnits": 4
+            "computeUnits": 4,
+            "defaultVolumeSize": 0
           },
           {
             "value": "8 CPU - 64GB RAM",
-            "computeUnits": 8
+            "computeUnits": 8,
+            "defaultVolumeSize": 0
           },
           {
             "value": "16 CPU - 128GB RAM",
-            "computeUnits": 16
+            "computeUnits": 16,
+            "defaultVolumeSize": 0
           },
           {
             "value": "32 CPU - 256GB RAM",
-            "computeUnits": 32
+            "computeUnits": 32,
+            "defaultVolumeSize": 0
           },
           {
             "value": "48 CPU - 384GB RAM",
-            "computeUnits": 48
+            "computeUnits": 48,
+            "defaultVolumeSize": 0
           },
           {
             "value": "64 CPU - 512GB RAM",
-            "computeUnits": 64
+            "computeUnits": 64,
+            "defaultVolumeSize": 0
           }
         ]
       }

--- a/src/state/nodes/machineSetupState.ts
+++ b/src/state/nodes/machineSetupState.ts
@@ -10,7 +10,8 @@ export interface MachineType {
 export interface VMSize {
   value: string;
   computeUnits: number;
-  defaultVolumeSize: number;
+  vcpus: number;
+  memoryGib: number;
 }
 
 export interface MachineSetup {

--- a/src/state/nodes/machineSetupState.ts
+++ b/src/state/nodes/machineSetupState.ts
@@ -10,6 +10,7 @@ export interface MachineType {
 export interface VMSize {
   value: string;
   computeUnits: number;
+  defaultVolumeSize: number;
 }
 
 export interface MachineSetup {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Display default node volume size in VM size dropdown
- Volume sizes mirror KCR's `volumeFormula` in [consumption-reporter](https://github.tools.sap/kyma/consumption-reporter) (`helm/kcr/values.yaml` + `templates/nodemeterconfig.yaml`)
- ...

**Related issue(s)**
#152
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
