### PR TITLE
fix: Model free standard storage block

### DIFF
--- a/src/calculatorFunctions/storageCosts/calculateStorageCosts.test.ts
+++ b/src/calculatorFunctions/storageCosts/calculateStorageCosts.test.ts
@@ -4,6 +4,7 @@ import { expect, test, describe } from 'vitest';
 // Config values (from config.json)
 // Storage.PricePerUnit = 0.02
 // Storage.Step = 32
+// Storage.FreeStorageBlocks = 1 (one 32-GB block is free on standard storage)
 // PremiumStorage.multiplier = 3
 // PremiumStorage.Step = 32
 // SnapshotStorage.multiplier = 1
@@ -34,10 +35,22 @@ describe('calculateStorageCosts — zero / boundary cases', () => {
 });
 
 describe('calculateStorageCosts — standard storage', () => {
-  test('calculates standard storage only — 1 block (32 GB)', () => {
-    // 0.02 * 720 * (32 / 32) = 14.4
+  test('the first block (32 GB) is free', () => {
+    // (32/32 - 1) free block = 0 billable blocks
     const storageCosts = calculateStorageCosts({
       GBQuantity: 32,
+      premiumGBQuantity: 0,
+      snapshotGBQuantity: 0,
+      timeConsumption: 720,
+    });
+
+    expect(storageCosts).toBe(0);
+  });
+
+  test('calculates standard storage — 2 blocks (64 GB), 1 free → bills 1 block', () => {
+    // 0.02 * 720 * (64/32 - 1) = 0.02 * 720 * 1 = 14.4
+    const storageCosts = calculateStorageCosts({
+      GBQuantity: 64,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 720,
@@ -46,10 +59,10 @@ describe('calculateStorageCosts — standard storage', () => {
     expect(storageCosts).toBe(14.4);
   });
 
-  test('calculates standard storage only — 2 blocks (64 GB)', () => {
-    // 0.02 * 720 * (64 / 32) = 28.8
+  test('calculates standard storage — 3 blocks (96 GB), 1 free → bills 2 blocks', () => {
+    // 0.02 * 720 * (96/32 - 1) = 0.02 * 720 * 2 = 28.8
     const storageCosts = calculateStorageCosts({
-      GBQuantity: 64,
+      GBQuantity: 96,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 720,
@@ -60,13 +73,13 @@ describe('calculateStorageCosts — standard storage', () => {
 
   test('standard storage scales linearly with timeConsumption', () => {
     const half = calculateStorageCosts({
-      GBQuantity: 64,
+      GBQuantity: 96,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 360,
     });
     const full = calculateStorageCosts({
-      GBQuantity: 64,
+      GBQuantity: 96,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 720,
@@ -89,13 +102,27 @@ describe('calculateStorageCosts — premium storage', () => {
     expect(storageCosts).toBeCloseTo(86.4, 5);
   });
 
-  test('premium storage costs exactly 3x standard for equal GB and time', () => {
+  test('premium storage is not discounted by the free standard block', () => {
+    // premium bills all blocks: 3 * 0.02 * 720 * (32/32) = 43.2
+    const premium = calculateStorageCosts({
+      GBQuantity: 0,
+      premiumGBQuantity: 32,
+      snapshotGBQuantity: 0,
+      timeConsumption: 720,
+    });
+
+    expect(premium).toBeCloseTo(43.2, 5);
+  });
+
+  test('premium storage costs exactly 3x standard for equal billable blocks', () => {
+    // standard gets 1 free block, so 96 GB → 2 billable blocks
     const standard = calculateStorageCosts({
-      GBQuantity: 64,
+      GBQuantity: 96,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 720,
     });
+    // premium has no free block, so 64 GB → 2 billable blocks
     const premium = calculateStorageCosts({
       GBQuantity: 0,
       premiumGBQuantity: 64,
@@ -120,13 +147,27 @@ describe('calculateStorageCosts — snapshot storage', () => {
     expect(storageCosts).toBe(28.8);
   });
 
-  test('snapshot storage costs the same as standard for equal GB and time (multiplier = 1)', () => {
+  test('snapshot storage is not discounted by the free standard block', () => {
+    // snapshot bills all blocks: 1 * 0.02 * 720 * (32/32) = 14.4
+    const snapshot = calculateStorageCosts({
+      GBQuantity: 0,
+      premiumGBQuantity: 0,
+      snapshotGBQuantity: 32,
+      timeConsumption: 720,
+    });
+
+    expect(snapshot).toBe(14.4);
+  });
+
+  test('snapshot storage costs the same as standard for equal billable blocks (multiplier = 1)', () => {
+    // standard gets 1 free block, so 96 GB → 2 billable blocks
     const standard = calculateStorageCosts({
-      GBQuantity: 64,
+      GBQuantity: 96,
       premiumGBQuantity: 0,
       snapshotGBQuantity: 0,
       timeConsumption: 720,
     });
+    // snapshot has no free block, so 64 GB → 2 billable blocks
     const snapshot = calculateStorageCosts({
       GBQuantity: 0,
       premiumGBQuantity: 0,
@@ -140,10 +181,10 @@ describe('calculateStorageCosts — snapshot storage', () => {
 
 describe('calculateStorageCosts — combined types', () => {
   test('total storage costs with all types combined', () => {
-    // standard: 0.02 * 516 * (1056/32) = 0.02 * 516 * 33 = 340.56
+    // standard: 0.02 * 516 * (1056/32 - 1) = 0.02 * 516 * 32 = 330.24
     // premium:  3 * 0.02 * 516 * (1056/32) = 3 * 340.56 = 1021.68
     // snapshot: 1 * 0.02 * 516 * (2048/32) = 0.02 * 516 * 64 = 660.48
-    // total: 340.56 + 1021.68 + 660.48 = 2022.72
+    // total: 330.24 + 1021.68 + 660.48 = 2012.4
     const storageCosts = calculateStorageCosts({
       GBQuantity: 1056,
       premiumGBQuantity: 1056,
@@ -151,7 +192,7 @@ describe('calculateStorageCosts — combined types', () => {
       timeConsumption: 516,
     });
 
-    expect(storageCosts).toBe(2022.72);
+    expect(storageCosts).toBe(2012.4);
   });
 
   test('combined costs equal sum of individual components', () => {

--- a/src/calculatorFunctions/storageCosts/calculateStorageCosts.ts
+++ b/src/calculatorFunctions/storageCosts/calculateStorageCosts.ts
@@ -14,8 +14,15 @@ export default function calculateStorageCosts(props: StorageCostProps): number {
   const premiumPPU: number = config.PremiumStorage.multiplier;
   const snapshotPPU: number = config.SnapshotStorage.multiplier;
 
+  // Standard storage gets a fixed number of free blocks before billing; premium
+  // (NFS) and snapshot do not.
+  const billableStandardBlocks: number = Math.max(
+    0,
+    GBQuantity / config.Storage.Step - config.Storage.FreeStorageBlocks,
+  );
+
   return (
-    PPU * timeConsumption * (GBQuantity / config.Storage.Step) +
+    PPU * timeConsumption * billableStandardBlocks +
     premiumPPU *
       PPU *
       timeConsumption *

--- a/src/calculatorFunctions/totalCosts/calculateTotalCosts.test.ts
+++ b/src/calculatorFunctions/totalCosts/calculateTotalCosts.test.ts
@@ -82,7 +82,9 @@ describe('calculateTotalCosts — additivity of cost components', () => {
       conversionRatio: 1.0,
     });
 
-    expect(totalCosts.CU).toBe(nodeConfigCosts + storageCosts + additionalCosts);
+    expect(totalCosts.CU).toBe(
+      nodeConfigCosts + storageCosts + additionalCosts,
+    );
   });
 
   test('nodeConfig cost contribution is isolated correctly', () => {
@@ -124,10 +126,10 @@ describe('calculateTotalCosts — General Purpose full scenario', () => {
     });
 
     // storage: standard=1024GB, premium=1024GB, snapshot=2048GB, time=450
-    // standard: 0.02 * 450 * 32 = 288
+    // standard: 0.02 * 450 * (32 - 1 free block) = 0.02 * 450 * 31 = 279
     // premium:  3 * 0.02 * 450 * 32 = 864
     // snapshot: 1 * 0.02 * 450 * 64 = 576
-    // total: 1728
+    // total: 1719
     const storageCosts = calculateStorageCosts({
       GBQuantity: 1024,
       premiumGBQuantity: 1024,
@@ -144,8 +146,9 @@ describe('calculateTotalCosts — General Purpose full scenario', () => {
       conversionRatio: 0.35,
     });
 
-    expect(totalCosts.CU).toBe(4394);
-    expect(totalCosts.CC.toFixed(2)).toBe('1537.90');
+    // 2592 + 1719 + 74 = 4385
+    expect(totalCosts.CU).toBe(4385);
+    expect(totalCosts.CC.toFixed(2)).toBe('1534.75');
   });
 });
 
@@ -161,9 +164,9 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
     });
 
     // storage: standard=64GB (2 blocks), premium=32GB (1 block), snapshot=0, time=720
-    // standard: 0.02 * 720 * 2 = 28.8
+    // standard: 0.02 * 720 * (2 - 1 free block) = 0.02 * 720 * 1 = 14.4
     // premium:  3 * 0.02 * 720 * 1 = 43.2
-    // total: 72
+    // total: 57.6
     const storageCosts = calculateStorageCosts({
       GBQuantity: 64,
       premiumGBQuantity: 32,
@@ -180,13 +183,18 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       conversionRatio: 1.0,
     });
 
-    // 1555.2 + 72 + 74 = 1701.2
-    expect(totalCosts.CU).toBeCloseTo(1701.2, 5);
-    expect(totalCosts.CC).toBeCloseTo(1701.2, 5);
+    // 1555.2 + 57.6 + 74 = 1686.8
+    expect(totalCosts.CU).toBeCloseTo(1686.8, 5);
+    expect(totalCosts.CC).toBeCloseTo(1686.8, 5);
   });
 
   test('Memory Intensive total costs higher than General Purpose for same config', () => {
-    const commonStorage = { GBQuantity: 64, premiumGBQuantity: 0, snapshotGBQuantity: 0, timeConsumption: 720 };
+    const commonStorage = {
+      GBQuantity: 64,
+      premiumGBQuantity: 0,
+      snapshotGBQuantity: 0,
+      timeConsumption: 720,
+    };
     const storageCosts = calculateStorageCosts(commonStorage);
     const additionalCosts = calculateAdditionalCosts({ redis: 0 });
 
@@ -203,8 +211,18 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       machineTypeFactor: 1.5,
     });
 
-    const gpTotal = calculateTotalCosts({ nodeConfigCosts: gpNodeCosts, storageCosts, additionalCosts, conversionRatio: 1 });
-    const miTotal = calculateTotalCosts({ nodeConfigCosts: miNodeCosts, storageCosts, additionalCosts, conversionRatio: 1 });
+    const gpTotal = calculateTotalCosts({
+      nodeConfigCosts: gpNodeCosts,
+      storageCosts,
+      additionalCosts,
+      conversionRatio: 1,
+    });
+    const miTotal = calculateTotalCosts({
+      nodeConfigCosts: miNodeCosts,
+      storageCosts,
+      additionalCosts,
+      conversionRatio: 1,
+    });
 
     expect(miTotal.CU).toBeGreaterThan(gpTotal.CU);
     expect(miTotal.CU).toBeCloseTo(gpTotal.CU * 1.5 - storageCosts * 0.5, 5);
@@ -221,10 +239,10 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
     });
 
     // storage: standard=128GB, premium=64GB, snapshot=128GB, time=720
-    // standard: 0.02 * 720 * 4 = 57.6
+    // standard: 0.02 * 720 * (4 - 1 free block) = 0.02 * 720 * 3 = 43.2
     // premium:  3 * 0.02 * 720 * 2 = 86.4
     // snapshot: 1 * 0.02 * 720 * 4 = 57.6
-    // total: 201.6
+    // total: 187.2
     const storageCosts = calculateStorageCosts({
       GBQuantity: 128,
       premiumGBQuantity: 64,
@@ -241,8 +259,8 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       conversionRatio: 0.5,
     });
 
-    // CU: 6220.8 + 201.6 + 773 = 7195.4
-    expect(totalCosts.CU).toBeCloseTo(7195.4, 5);
-    expect(totalCosts.CC).toBeCloseTo(7195.4 * 0.5, 5);
+    // CU: 6220.8 + 187.2 + 773 = 7181
+    expect(totalCosts.CU).toBeCloseTo(7181, 5);
+    expect(totalCosts.CC).toBeCloseTo(7181 * 0.5, 5);
   });
 });

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
   "CurrencyCode": "€",
-  "ConversionRateCUCC": 1.00,
+  "ConversionRateCUCC": 1.0,
   "nodeConfig": {
     "AutoScalerMin": {
       "Default": 3,
@@ -173,7 +173,8 @@
     "Min": 0,
     "Max": 3200,
     "Step": 32,
-    "PricePerUnit": 0.02
+    "PricePerUnit": 0.02,
+    "FreeStorageBlocks": 1
   },
   "PremiumStorage": {
     "Default": 0,

--- a/tests/cost.ts
+++ b/tests/cost.ts
@@ -104,14 +104,15 @@ const stepsPrice: Map<Step, Price> = new Map<Step, Price>([
     },
   ],
   [
+    // 160 GB = 5 blocks − 1 free standard block: 0.02 * 720 * 4 = 57.6
     Step.STORAGE_GB_INCREASE,
     {
       Nodes: 0,
       Additional: 0,
-      Storage: 72,
+      Storage: 57.6,
       TotalCost: {
-        CapacityUnits: 72,
-        Currency: 72,
+        CapacityUnits: 57.6,
+        Currency: 57.6,
       },
     },
   ],


### PR DESCRIPTION
**Description**
- **What:** Standard storage now bills one fewer 32-GiB block, matching the [consumption reporter](https://github.tools.sap/kyma/consumption-reporter) (ground truth for pricing).
- **Why:** The consumption reporter gives every cluster one 32-GiB block of standard storage for free (it's reserved for system logs). Our calculator was charging for that block too, so it overestimated cost by about 14.4 CU/month for anyone using standard storage.
- **How:**
     - `config.json`: add a `Storage.FreeStorageBlocks` setting (set to 1)
     - `calculateStorageCosts`: subtract the free block from standard storage before pricing, and never go below zero. NFS and snapshot storage are unchanged — they don't get a free block.
-  **Tests:** Updated unit tests (`calculateStorageCosts`, `calculateTotalCosts`) and the Cypress storage step for the new amounts.