### PR TITLE
fix: Time-scale Redis cost like storage

### DIFF
--- a/src/calculatorFunctions/additionalConfig/calculateAdditionalCosts.test.ts
+++ b/src/calculatorFunctions/additionalConfig/calculateAdditionalCosts.test.ts
@@ -1,94 +1,113 @@
 import calculateAdditionalCosts from './calculateAdditionalCosts';
 import { expect, test, describe } from 'vitest';
 
-// Redis costs are flat monthly CU values — NOT scaled by time.
-// Tier values (from config.json RedisCosts.Tiers):
-//   None=0, Standard1=74, Standard2=148, Standard3=387, Standard4=778,
-//   Standard5=1541, Standard6=3084, Standard7=6167, Standard8=12331,
-//   Premium1=773, Premium2=1555, Premium3=3082, Premium4=6167,
-//   Premium5=12335, Premium6=24661
+// Redis cost = (storageGb / 32) blocks * 0.02 rate * timeConsumption.
+// Tier GB values come from config.json RedisCosts.Tiers.
+
+const RATE = 0.02;
+const BLOCK = 32;
+const MONTH = 720;
+
+const expectedCost = (storageGb: number, time: number) =>
+  (storageGb / BLOCK) * RATE * time;
 
 describe('calculateAdditionalCosts — no Redis', () => {
-  test('returns zero when redis is zero (None tier)', () => {
-    expect(calculateAdditionalCosts({ redis: 0 })).toBe(0);
+  test('returns zero when there is no redis storage (None tier)', () => {
+    expect(
+      calculateAdditionalCosts({ redisStorageGb: 0, timeConsumption: 720 }),
+    ).toBe(0);
+  });
+
+  test('returns zero when timeConsumption is zero', () => {
+    expect(
+      calculateAdditionalCosts({ redisStorageGb: 182, timeConsumption: 0 }),
+    ).toBe(0);
   });
 });
 
-describe('calculateAdditionalCosts — Standard Redis tiers', () => {
-  test('Standard1 tier (74 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 74 })).toBe(74);
+describe('calculateAdditionalCosts — Standard Redis tiers (full month)', () => {
+  test('Standard1 (182 GB) → 81.9 CU', () => {
+    expect(
+      calculateAdditionalCosts({ redisStorageGb: 182, timeConsumption: MONTH }),
+    ).toBeCloseTo(81.9, 5);
   });
 
-  test('Standard2 tier (148 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 148 })).toBe(148);
+  test('Standard4 (1915 GB) → 861.75 CU', () => {
+    expect(
+      calculateAdditionalCosts({
+        redisStorageGb: 1915,
+        timeConsumption: MONTH,
+      }),
+    ).toBeCloseTo(861.75, 5);
   });
 
-  test('Standard3 tier (387 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 387 })).toBe(387);
-  });
-
-  test('Standard4 tier (778 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 778 })).toBe(778);
-  });
-
-  test('Standard5 tier (1541 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 1541 })).toBe(1541);
-  });
-
-  test('Standard6 tier (3084 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 3084 })).toBe(3084);
-  });
-
-  test('Standard7 tier (6167 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 6167 })).toBe(6167);
-  });
-
-  test('Standard8 tier (12331 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 12331 })).toBe(12331);
+  test('Standard8 (30353 GB)', () => {
+    expect(
+      calculateAdditionalCosts({
+        redisStorageGb: 30353,
+        timeConsumption: MONTH,
+      }),
+    ).toBeCloseTo(expectedCost(30353, MONTH), 10);
   });
 });
 
-describe('calculateAdditionalCosts — Premium Redis tiers', () => {
-  test('Premium1 tier (773 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 773 })).toBe(773);
+describe('calculateAdditionalCosts — Premium Redis tiers (full month)', () => {
+  test('Premium1 (1903 GB)', () => {
+    expect(
+      calculateAdditionalCosts({
+        redisStorageGb: 1903,
+        timeConsumption: MONTH,
+      }),
+    ).toBeCloseTo(expectedCost(1903, MONTH), 10);
   });
 
-  test('Premium2 tier (1555 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 1555 })).toBe(1555);
-  });
-
-  test('Premium3 tier (3082 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 3082 })).toBe(3082);
-  });
-
-  test('Premium4 tier (6167 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 6167 })).toBe(6167);
-  });
-
-  test('Premium5 tier (12335 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 12335 })).toBe(12335);
-  });
-
-  test('Premium6 tier (24661 CU)', () => {
-    expect(calculateAdditionalCosts({ redis: 24661 })).toBe(24661);
+  test('Premium6 (60704 GB) → 27316.8 CU', () => {
+    expect(
+      calculateAdditionalCosts({
+        redisStorageGb: 60704,
+        timeConsumption: MONTH,
+      }),
+    ).toBeCloseTo(27316.8, 5);
   });
 });
 
-describe('calculateAdditionalCosts — flat-rate behaviour', () => {
-  test('returns redis cost as-is (pass-through)', () => {
-    expect(calculateAdditionalCosts({ redis: 74 })).toBe(74);
+describe('calculateAdditionalCosts — time scaling', () => {
+  test('redis cost scales linearly with timeConsumption', () => {
+    const half = calculateAdditionalCosts({
+      redisStorageGb: 1915,
+      timeConsumption: 360,
+    });
+    const full = calculateAdditionalCosts({
+      redisStorageGb: 1915,
+      timeConsumption: 720,
+    });
+
+    expect(full).toBeCloseTo(half * 2, 10);
   });
 
-  test('redis cost is a flat monthly amount — same value regardless of context', () => {
-    // Calling twice with the same input must always return the same value
-    const first = calculateAdditionalCosts({ redis: 387 });
-    const second = calculateAdditionalCosts({ redis: 387 });
-    expect(first).toBe(second);
+  test('a partial month costs less than a full month', () => {
+    const partial = calculateAdditionalCosts({
+      redisStorageGb: 182,
+      timeConsumption: 360,
+    });
+    const full = calculateAdditionalCosts({
+      redisStorageGb: 182,
+      timeConsumption: 720,
+    });
+
+    expect(partial).toBeLessThan(full);
   });
 
-  test('Premium1 (773) costs less than Standard8 (12331)', () => {
-    const premium1 = calculateAdditionalCosts({ redis: 773 });
-    const standard8 = calculateAdditionalCosts({ redis: 12331 });
+  test('Premium1 costs less than Standard8 for the same time', () => {
+    const premium1 = calculateAdditionalCosts({
+      redisStorageGb: 1903,
+      timeConsumption: MONTH,
+    });
+    const standard8 = calculateAdditionalCosts({
+      redisStorageGb: 30353,
+      timeConsumption: MONTH,
+    });
+
     expect(premium1).toBeLessThan(standard8);
   });
 });

--- a/src/calculatorFunctions/additionalConfig/calculateAdditionalCosts.ts
+++ b/src/calculatorFunctions/additionalConfig/calculateAdditionalCosts.ts
@@ -1,11 +1,16 @@
+import config from '../../config.json';
+
 interface Props {
-  redis: number;
+  redisStorageGb: number;
+  timeConsumption: number;
 }
 
-// Redis costs are flat monthly CU values per tier (not hourly rates),
-// so they are not scaled by timeConsumption unlike node and storage costs.
+// Redis is billed like storage: GB are converted to 32-GiB blocks, then priced
+// at the storage block rate and scaled by time consumption.
 export default function calculateAdditionalCosts(props: Props): number {
-  const { redis } = props;
+  const { redisStorageGb, timeConsumption } = props;
 
-  return redis;
+  const redisStorageBlocks = redisStorageGb / config.Storage.Step;
+
+  return redisStorageBlocks * config.Storage.PricePerUnit * timeConsumption;
 }

--- a/src/calculatorFunctions/totalCosts/calculateTotalCosts.test.ts
+++ b/src/calculatorFunctions/totalCosts/calculateTotalCosts.test.ts
@@ -1,6 +1,5 @@
 import calculateNodeConfigCosts from '../nodeConfigCosts/calculateNodeConfigCosts';
 import calculateStorageCosts from '../storageCosts/calculateStorageCosts';
-import calculateAdditionalCosts from '../additionalConfig/calculateAdditionalCosts';
 import calculateTotalCosts from './calculateTotalCosts';
 
 import { expect, test, describe } from 'vitest';
@@ -82,7 +81,9 @@ describe('calculateTotalCosts — additivity of cost components', () => {
       conversionRatio: 1.0,
     });
 
-    expect(totalCosts.CU).toBe(nodeConfigCosts + storageCosts + additionalCosts);
+    expect(totalCosts.CU).toBe(
+      nodeConfigCosts + storageCosts + additionalCosts,
+    );
   });
 
   test('nodeConfig cost contribution is isolated correctly', () => {
@@ -135,7 +136,7 @@ describe('calculateTotalCosts — General Purpose full scenario', () => {
       timeConsumption: 450,
     });
 
-    const additionalCosts = calculateAdditionalCosts({ redis: 74 });
+    const additionalCosts = 74; // representative redis (additional) cost
 
     const totalCosts = calculateTotalCosts({
       nodeConfigCosts,
@@ -171,7 +172,7 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       timeConsumption: 720,
     });
 
-    const additionalCosts = calculateAdditionalCosts({ redis: 74 });
+    const additionalCosts = 74; // representative redis (additional) cost
 
     const totalCosts = calculateTotalCosts({
       nodeConfigCosts,
@@ -186,9 +187,14 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
   });
 
   test('Memory Intensive total costs higher than General Purpose for same config', () => {
-    const commonStorage = { GBQuantity: 64, premiumGBQuantity: 0, snapshotGBQuantity: 0, timeConsumption: 720 };
+    const commonStorage = {
+      GBQuantity: 64,
+      premiumGBQuantity: 0,
+      snapshotGBQuantity: 0,
+      timeConsumption: 720,
+    };
     const storageCosts = calculateStorageCosts(commonStorage);
-    const additionalCosts = calculateAdditionalCosts({ redis: 0 });
+    const additionalCosts = 0;
 
     const gpNodeCosts = calculateNodeConfigCosts({
       timeConsumption: 720,
@@ -203,8 +209,18 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       machineTypeFactor: 1.5,
     });
 
-    const gpTotal = calculateTotalCosts({ nodeConfigCosts: gpNodeCosts, storageCosts, additionalCosts, conversionRatio: 1 });
-    const miTotal = calculateTotalCosts({ nodeConfigCosts: miNodeCosts, storageCosts, additionalCosts, conversionRatio: 1 });
+    const gpTotal = calculateTotalCosts({
+      nodeConfigCosts: gpNodeCosts,
+      storageCosts,
+      additionalCosts,
+      conversionRatio: 1,
+    });
+    const miTotal = calculateTotalCosts({
+      nodeConfigCosts: miNodeCosts,
+      storageCosts,
+      additionalCosts,
+      conversionRatio: 1,
+    });
 
     expect(miTotal.CU).toBeGreaterThan(gpTotal.CU);
     expect(miTotal.CU).toBeCloseTo(gpTotal.CU * 1.5 - storageCosts * 0.5, 5);
@@ -232,7 +248,7 @@ describe('calculateTotalCosts — Memory Intensive full scenario', () => {
       timeConsumption: 720,
     });
 
-    const additionalCosts = calculateAdditionalCosts({ redis: 773 }); // Premium1
+    const additionalCosts = 773; // representative redis (additional) cost
 
     const totalCosts = calculateTotalCosts({
       nodeConfigCosts,

--- a/src/components/CostWizard/Functions/exportToFile.ts
+++ b/src/components/CostWizard/Functions/exportToFile.ts
@@ -4,6 +4,7 @@ import { MachineSetup } from '../../../state/nodes/machineSetupState';
 import { RedisSize } from '../../../state/additionalConfig/redisState';
 import { TotalCosts } from '../../../calculatorFunctions/totalCosts/calculateTotalCosts';
 import calculateNodeConfigCosts from '../../../calculatorFunctions/nodeConfigCosts/calculateNodeConfigCosts';
+import calculateAdditionalCosts from '../../../calculatorFunctions/additionalConfig/calculateAdditionalCosts';
 import config from '../../../config.json';
 
 interface Props {
@@ -85,7 +86,16 @@ export default function exportToFile(props: Props) {
   dataArray.push(
     ['Additional Configuration'],
     ['Redis Tier', redisSize.tier],
-    ['Redis Cost', `${roundDecimals(redisSize.value, true)} CU`],
+    [
+      'Redis Cost',
+      `${roundDecimals(
+        calculateAdditionalCosts({
+          redisStorageGb: redisSize.storageGb,
+          timeConsumption,
+        }),
+        true,
+      )} CU`,
+    ],
     ['Conversion Rate', conversionRate],
     [''],
   );

--- a/src/components/CostWizard/UserInputs/additionalConfig/RedisSelect.tsx
+++ b/src/components/CostWizard/UserInputs/additionalConfig/RedisSelect.tsx
@@ -14,7 +14,7 @@ export default function RedisSelect() {
   }) => {
     const selection = event.detail.selectedOption.dataset;
     setRedisSize({
-      value: +(selection.value ?? '0'),
+      storageGb: +(selection.storageGb ?? '0'),
       tier: selection.key ?? '',
     });
   };
@@ -41,7 +41,11 @@ export default function RedisSelect() {
       </FlexBox>
       <Select className="redis-select" onChange={onChange} id="redis-select">
         {redisConfigOptions.map((item) => (
-          <Option key={item.key} data-key={item.key} data-value={item.value}>
+          <Option
+            key={item.key}
+            data-key={item.key}
+            data-storage-gb={item.storageGb}
+          >
             {item.key}
           </Option>
         ))}

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
   "CurrencyCode": "€",
-  "ConversionRateCUCC": 1.00,
+  "ConversionRateCUCC": 1.0,
   "nodeConfig": {
     "AutoScalerMin": {
       "Default": 3,
@@ -191,21 +191,21 @@
   },
   "RedisCosts": {
     "Tiers": [
-      { "key": "None", "value": 0 },
-      { "key": "Standard1", "value": 74 },
-      { "key": "Standard2", "value": 148 },
-      { "key": "Standard3", "value": 387 },
-      { "key": "Standard4", "value": 778 },
-      { "key": "Standard5", "value": 1541 },
-      { "key": "Standard6", "value": 3084 },
-      { "key": "Standard7", "value": 6167 },
-      { "key": "Standard8", "value": 12331 },
-      { "key": "Premium1", "value": 773 },
-      { "key": "Premium2", "value": 1555 },
-      { "key": "Premium3", "value": 3082 },
-      { "key": "Premium4", "value": 6167 },
-      { "key": "Premium5", "value": 12335 },
-      { "key": "Premium6", "value": 24661 }
+      { "key": "None", "storageGb": 0 },
+      { "key": "Standard1", "storageGb": 182 },
+      { "key": "Standard2", "storageGb": 364 },
+      { "key": "Standard3", "storageGb": 953 },
+      { "key": "Standard4", "storageGb": 1915 },
+      { "key": "Standard5", "storageGb": 3793 },
+      { "key": "Standard6", "storageGb": 7591 },
+      { "key": "Standard7", "storageGb": 15180 },
+      { "key": "Standard8", "storageGb": 30353 },
+      { "key": "Premium1", "storageGb": 1903 },
+      { "key": "Premium2", "storageGb": 3828 },
+      { "key": "Premium3", "storageGb": 7586 },
+      { "key": "Premium4", "storageGb": 15180 },
+      { "key": "Premium5", "storageGb": 30363 },
+      { "key": "Premium6", "storageGb": 60704 }
     ]
   },
   "documentationUrls": {

--- a/src/state/additionalConfig/redisState.ts
+++ b/src/state/additionalConfig/redisState.ts
@@ -3,11 +3,11 @@ import config from '../../config.json';
 
 export interface RedisSize {
   tier: string;
-  value: number;
+  storageGb: number;
 }
 
 export const redisState = atom<RedisSize>({
   tier: config.RedisCosts.Tiers[0].key,
-  value: config.RedisCosts.Tiers[0].value,
+  storageGb: config.RedisCosts.Tiers[0].storageGb,
 });
 redisState.debugLabel = 'redisState';

--- a/src/state/costState.ts
+++ b/src/state/costState.ts
@@ -53,7 +53,11 @@ storageCostsAtom.debugLabel = 'storageCostsAtom';
 
 export const additionalCostsAtom = atom<number>((get) => {
   const redis = get(redisState);
-  return calculateAdditionalCosts({ redis: redis.value });
+  const timeConsumption = get(timeConsumptionState);
+  return calculateAdditionalCosts({
+    redisStorageGb: redis.storageGb,
+    timeConsumption,
+  });
 });
 additionalCostsAtom.debugLabel = 'additionalCostsAtom';
 

--- a/tests/cost.ts
+++ b/tests/cost.ts
@@ -128,14 +128,15 @@ const stepsPrice: Map<Step, Price> = new Map<Step, Price>([
     },
   ],
   [
+    // Standard4 (1915 GB) at default 720h: (1915 / 32) * 0.02 * 720 = 861.75
     Step.ADDITIONAL_REDIS_INCREASE,
     {
       Nodes: 0,
-      Additional: 778,
+      Additional: 861.75,
       Storage: 0,
       TotalCost: {
-        CapacityUnits: 778,
-        Currency: 778,
+        CapacityUnits: 861.75,
+        Currency: 861.75,
       },
     },
   ],


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

- **What:** Redis cost is now derived from the tier's storage size and scaled by usage time, instead of a flat monthly CU value. 
- **Why:** The [consumption reporter](https://github.tools.sap/kyma/consumption-reporter) (ground truth) sizes each Redis tier in GB, splits that into 32-GiB blocks, and charges the normal storage rate for the time it's used. Our calculator used a flat per-tier price that ignored runtime — so it undercharged a full month by about 9.7% and overcharged shorter periods.
- **How:**
     - `config.json`: each Redis tier now stores its storage size in GB (matching the billing system) instead of a fixed price.
     - `calculateAdditionalCosts`: `(storageGb / 32) × Storage.PricePerUnit × timeConsumption`
     - Pass usage time through to the Redis calculation (state and file export).
- **Tests:** Updated `calculateAdditionalCosts`, `calculateTotalCosts`, and the Cypress redis step (Standard4 → 861.75 CU at 720h).