### PR TITLE
fix: UI not behaving responsively for wide-screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,3 @@
 .App {
-  margin-top: 7.5vh;
+  margin-top: var(--page-top-offset);
 }

--- a/src/components/CostWizard/AddWorkerNodes.css
+++ b/src/components/CostWizard/AddWorkerNodes.css
@@ -1,14 +1,17 @@
-.workernode-name {
-  font-size: x-large;
-}
-
-.dynamic-worker-node-container {
-  margin-top: 20px;
-}
-
 .add-worker-node-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-top: 10px;
   margin-bottom: 20px;
+}
+
+.worker-node-pool-summary {
+  font-size: var(--sapFontSmallSize);
+  color: var(--sapContent_LabelColor);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .help-portal-link {

--- a/src/components/CostWizard/AddWorkerNodes.tsx
+++ b/src/components/CostWizard/AddWorkerNodes.tsx
@@ -1,19 +1,62 @@
+import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { Button, FlexBox, Icon, Title } from '@ui5/webcomponents-react';
+import { Button, FlexBox, Panel, Title } from '@ui5/webcomponents-react';
+import '@ui5/webcomponents-icons/dist/delete.js';
 import './AddWorkerNodes.css';
 import {
   additionalMachineSetupState,
   MachineSetup,
 } from '../../state/nodes/machineSetupState';
 import MachineSetupForm from './MachineSetupForm';
-import openLinks from './Functions/openLinks';
 import config from '../../config.json';
+
+interface PoolHeaderProps {
+  slot?: string;
+  title: string;
+  summary: string;
+  collapsed: boolean;
+  onRemove: () => void;
+}
+
+function PoolHeader({ slot, title, summary, collapsed, onRemove }: PoolHeaderProps) {
+  return (
+    <FlexBox
+      slot={slot}
+      className="worker-node-pool-header"
+      alignItems="Center"
+      justifyContent="SpaceBetween"
+      fitContainer
+      wrap="NoWrap"
+    >
+      <FlexBox direction="Column">
+        <Title level="H4" size="H4">
+          {title}
+        </Title>
+        {collapsed && (
+          <span className="worker-node-pool-summary">{summary}</span>
+        )}
+      </FlexBox>
+      <Button
+        icon="delete"
+        design="Transparent"
+        tooltip="Remove worker node pool"
+        accessibleName="Remove worker node pool"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+      />
+    </FlexBox>
+  );
+}
 
 export default function AddWorkerNodes() {
   const [machineSetup, setMachineSetup] = useAtom(additionalMachineSetupState);
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
 
   const addMachineSetup = () => {
     const newMachine: MachineSetup = {
+      id: crypto.randomUUID(),
       machineType: config.nodeConfig.MachineTypes[0],
       VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
       minAutoscaler: config.nodeConfig.AutoScalerMin.DefaultWorkerNodes,
@@ -22,46 +65,53 @@ export default function AddWorkerNodes() {
     setMachineSetup((prevState) => prevState.concat(newMachine));
   };
 
-  const updateMachineSetup = (index: number, updatedMachine: MachineSetup) => {
+  const updateMachineSetup = (id: string, updatedMachine: MachineSetup) => {
     setMachineSetup((prevState) =>
-      prevState.map((machine, i) => (i === index ? updatedMachine : machine)),
+      prevState.map((machine) => (machine.id === id ? updatedMachine : machine)),
     );
   };
 
-  const removeMachineSetup = (index: number) => {
-    setMachineSetup((prevState) => prevState.filter((_, i) => i !== index));
+  const removeMachineSetup = (id: string) => {
+    setMachineSetup((prevState) => prevState.filter((machine) => machine.id !== id));
+  };
+
+  const handleToggle = (id: string, collapsed: boolean) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (collapsed) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
   };
 
   return (
     <div className="add-worker-node-container">
       {machineSetup.map((machine, index) => (
-        <div
-          className="dynamic-worker-node-container"
-          key={`machine-setup-${index}`}
+        <Panel
+          key={machine.id}
           id={`machine-setup-${index}`}
+          headerLevel="H4"
+          onToggle={(event) => handleToggle(machine.id, event.target.collapsed)}
+          header={
+            <PoolHeader
+              title={`Worker Node Pool ${index + 1}`}
+              summary={`${machine.machineType.value} · ${machine.VMSize.value} · min ${machine.minAutoscaler}`}
+              collapsed={collapsedIds.has(machine.id)}
+              onRemove={() => removeMachineSetup(machine.id)}
+            />
+          }
         >
-          <FlexBox
-            wrap="NoWrap"
-            alignItems="Center"
-            fitContainer
-            displayInline
-            justifyContent="SpaceBetween"
-          >
-            <Title className="workernode-name" level="H2" size="H2">
-              Worker Node Pool {index}
-            </Title>
-            <Button icon="decline" onClick={() => removeMachineSetup(index)}>
-              Remove Worker Node Pool
-            </Button>
-          </FlexBox>
           <MachineSetupForm
             machine={machine}
             updateMachine={(updatedMachine: MachineSetup) =>
-              updateMachineSetup(index, updatedMachine)
+              updateMachineSetup(machine.id, updatedMachine)
             }
             workerNode={true}
           />
-        </div>
+        </Panel>
       ))}
       <FlexBox
         wrap="NoWrap"
@@ -73,13 +123,6 @@ export default function AddWorkerNodes() {
         <Button icon="add" onClick={addMachineSetup}>
           Add Worker Node Pool
         </Button>
-        <Icon
-          className="help-portal-link"
-          design="Information"
-          mode="Interactive"
-          name="sys-help"
-          onClick={() => openLinks('worker-node-pools')}
-        />
       </FlexBox>
     </div>
   );

--- a/src/components/CostWizard/CostWizard.css
+++ b/src/components/CostWizard/CostWizard.css
@@ -1,8 +1,3 @@
-#CostWizard {
-  height: 100%;
-  overflow-x: hidden;
-}
-
 .ButtonContainer {
   display: flex;
   justify-content: space-between;

--- a/src/components/CostWizard/MachineSetupForm.tsx
+++ b/src/components/CostWizard/MachineSetupForm.tsx
@@ -58,7 +58,7 @@ export default function MachineSetupForm({
   );
 
   return (
-    <Form>
+    <Form layout="S1 M1 L1 XL1">
       <MachineTypeSelect
         machineType={machine.machineType}
         setMachineType={setMachineType}

--- a/src/components/CostWizard/UserInputs/additionalConfig/ConversionRateInput.tsx
+++ b/src/components/CostWizard/UserInputs/additionalConfig/ConversionRateInput.tsx
@@ -2,26 +2,10 @@ import { useAtom } from 'jotai';
 import config from '../../../../config.json';
 import { Slider, Title } from '@ui5/webcomponents-react';
 import { applyConversionRateState } from '../../../../state/additionalConfig/applyConversionRateState';
-import InfoField from '../../common/InfoField';
 import SpinnerInput from '../common/SpinnerInput';
 
 export default function ConversionRateInput() {
   const [value, setValue] = useAtom(applyConversionRateState);
-
-  const text = (
-    <>
-      <div>
-        With the '<strong>conversion rate</strong>' you can change the amount of{' '}
-        <strong>{config.CurrencyCode}</strong> you are paying for{' '}
-        <strong>1 Capacity Unit</strong>.
-      </div>
-      <div>This will help you to calculate eventual discounts.</div>
-      <div>
-        If you are unsure about how to change the default value (
-        {config.ConversionRateCUCC.toFixed(2)}), please ask your SAP Sales Specialist.
-      </div>{' '}
-    </>
-  );
 
   const min = 0.01;
   const max = 1.2;
@@ -34,7 +18,6 @@ export default function ConversionRateInput() {
 
   return (
     <div>
-      <InfoField info={text} />
       <Title className="wizard-subheader" level="H5" size="H5">
         Conversion rate from Capacity Units to {config.CurrencyCode}
       </Title>

--- a/src/components/CostWizard/UserInputs/nodes/AdditionalNodeVolumeInputField.tsx
+++ b/src/components/CostWizard/UserInputs/nodes/AdditionalNodeVolumeInputField.tsx
@@ -28,7 +28,7 @@ export default function AdditionalNodeVolumeInputField({
   });
 
   return (
-    <>
+    <div>
       <HeaderWithInfo
         header="Additional Volume (GB)"
         info={`machine includes ${machineDefaultVolume} GB free; extra is billed in 32 GB blocks`}
@@ -50,6 +50,6 @@ export default function AdditionalNodeVolumeInputField({
         step={step}
         showTooltip
       />
-    </>
+    </div>
   );
 }

--- a/src/components/CostWizard/WizardSteps/AdditionalConfigStep.tsx
+++ b/src/components/CostWizard/WizardSteps/AdditionalConfigStep.tsx
@@ -3,14 +3,33 @@ import XlsxDownloadButton from '../Buttons/XlsxDownloadButton';
 import CSVDownloadButton from '../Buttons/CSVDownloadButton';
 import ConversionRateInput from '../UserInputs/additionalConfig/ConversionRateInput';
 import Redis from '../UserInputs/additionalConfig/RedisSelect';
+import InfoField from '../common/InfoField';
 import { WizardStep, Title } from '@ui5/webcomponents-react';
+import config from '../../../config.json';
 
 export default function AdditionalConfigStep() {
+  const conversionRateInfo = (
+    <>
+      <div>
+        With the '<strong>conversion rate</strong>' you can change the amount of{' '}
+        <strong>{config.CurrencyCode}</strong> you are paying for{' '}
+        <strong>1 Capacity Unit</strong>. This will help you to calculate
+        eventual discounts.
+      </div>
+      <div>
+        If you are unsure about how to change the default value (
+        {config.ConversionRateCUCC.toFixed(2)}), please ask your SAP Sales
+        Specialist.
+      </div>
+    </>
+  );
+
   return (
     <WizardStep disabled titleText="Additional Configuration">
       <Title wrappingType="Normal" level="H2" size="H2">
         4. Additional configuration options
       </Title>
+      <InfoField info={conversionRateInfo} />
       <div className="StepContent">
         <ConversionRateInput />
         <Redis />

--- a/src/components/CostWizard/WizardSteps/WorkerNodesStep.tsx
+++ b/src/components/CostWizard/WizardSteps/WorkerNodesStep.tsx
@@ -1,14 +1,24 @@
-import { Title, WizardStep } from '@ui5/webcomponents-react';
+import { FlexBox, Icon, Title, WizardStep } from '@ui5/webcomponents-react';
 import NextStepButton from '../Buttons/NextStepButton';
 import PreviousStepButton from '../Buttons/PreviousStepButton';
 import AddWorkerNodes from '../AddWorkerNodes';
+import openLinks from '../Functions/openLinks';
 
 export default function WorkerNodesStep() {
   return (
     <WizardStep disabled titleText="Worker Node Pools">
-      <Title wrappingType="Normal" level="H2" size="H2">
-        2. Add more worker node pools
-      </Title>
+      <FlexBox alignItems="Center" wrap="NoWrap">
+        <Title wrappingType="Normal" level="H2" size="H2">
+          2. Add more worker node pools
+        </Title>
+        <Icon
+          className="help-portal-link"
+          design="Information"
+          mode="Interactive"
+          name="sys-help"
+          onClick={() => openLinks('worker-node-pools')}
+        />
+      </FlexBox>
       <div className="StepContent">
         <AddWorkerNodes />
       </div>

--- a/src/components/CostWizard/common/InfoField.css
+++ b/src/components/CostWizard/common/InfoField.css
@@ -1,3 +1,4 @@
 .info {
+  width: 100%;
   margin-top: 1vh;
 }

--- a/src/components/Navigation/Navbar.css
+++ b/src/components/Navigation/Navbar.css
@@ -1,6 +1,11 @@
+/* block, not the default inline-block whose line box adds phantom space below the fixed bar. */
+ui5-shellbar {
+  display: block;
+}
+
 ui5-shellbar::part(root) {
   padding-left: 1rem;
-  min-height: 7.5vh;
+  min-height: 3.5rem;
   border-bottom: 2.5px solid rgb(41, 114, 234);
   background-color: white;
   position: fixed;

--- a/src/components/PageLayout/MainContentContainer.css
+++ b/src/components/PageLayout/MainContentContainer.css
@@ -2,7 +2,6 @@
   width: 100%;
   display: flex;
   gap: 0px;
-  overflow: hidden;
 }
 
 .main-content,
@@ -17,6 +16,7 @@
 }
 
 .side-content {
+  padding-top: 25px;
   padding-right: 20px;
 }
 

--- a/src/components/PageLayout/SideContent.css
+++ b/src/components/PageLayout/SideContent.css
@@ -6,7 +6,6 @@
   border: 3.5px solid rgb(165, 219, 255);
   border-radius: 10px;
   padding: 10px;
-  height: calc(100% - 25px);
 }
 
 #SideHeader {

--- a/src/components/PageLayout/SideContent.css
+++ b/src/components/PageLayout/SideContent.css
@@ -1,5 +1,8 @@
 #SideContent {
-  margin-top: 25px;
+  position: sticky;
+  /* Matches the rest position (offset + parent's 25px padding) so it clamps without a jump.
+     Keep margin-top off a sticky element: it shifts the stuck position and causes drift. */
+  top: calc(var(--page-top-offset) + 25px);
   margin-left: -60px;
   margin-right: 5px;
   background-color: rgb(229, 243, 254);
@@ -54,6 +57,7 @@
 
 @media (max-width: 960px) {
   #SideContent {
+    position: static;
     margin: 40px 0 0;
     padding-left: 5%;
     padding-right: 5%;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+:root {
+  /* Content top offset (navbar height + gap); shared by the .App margin and the sticky
+     panel's `top` so they can't desync. */
+  --page-top-offset: calc(3.5rem + 20px);
+}
+
 body {
   margin: 0;
   font-family:

--- a/src/state/nodes/machineSetupState.ts
+++ b/src/state/nodes/machineSetupState.ts
@@ -15,6 +15,7 @@ export interface VMSize {
 }
 
 export interface MachineSetup {
+  id: string;
   machineType: MachineType;
   minAutoscaler: number;
   VMSize: VMSize;
@@ -22,6 +23,7 @@ export interface MachineSetup {
 }
 
 export const baseMachineSetupState = atom<MachineSetup>({
+  id: 'base',
   machineType: config.nodeConfig.MachineTypes[0],
   VMSize: config.nodeConfig.MachineTypes[0].VMSizeOptions[0],
   minAutoscaler: config.nodeConfig.AutoScalerMin.Default,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixed wizard UI not behaving responsively for wide-screens
- made the "Resulting total costs" panel stick in view while scrolling through long wizard steps
- redesigned the worker node pools step as collapsible panels with an icon-only remove button and a config summary shown when collapsed


**Related issue(s)**
#173
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
